### PR TITLE
Adds default 2GB of RAM

### DIFF
--- a/Customfile
+++ b/Customfile
@@ -1,0 +1,3 @@
+config.vm.provider :virtualbox do |v|
+  v.customize ["modifyvm", :id, "--memory", 2048]
+end


### PR DESCRIPTION
After complaints about default machine not being able to start for memory reasons, I've increased the default size of the virtualbox to 2GB.
